### PR TITLE
feat(auth): increase response timeout of verifier to 10s

### DIFF
--- a/API/auth-service/src/controllers/AuthController.ts
+++ b/API/auth-service/src/controllers/AuthController.ts
@@ -178,10 +178,10 @@ class AuthController {
 		let payload;
 		switch (type) {
 			case ETokenType.ACCESS:
-				payload = await JwtService.verifyAccessToken(token);
+				payload = await JwtService.verifyToken(token, "access");
 				break;
 			case ETokenType.ID:
-				payload = await JwtService.verifyIdToken(token);
+				payload = await JwtService.verifyToken(token, "id");
 				break;
 			default:
 				throw new BadRequestError(`Invalid token type: ${tokenType}`);

--- a/API/auth-service/src/controllers/GrpcAuthController.ts
+++ b/API/auth-service/src/controllers/GrpcAuthController.ts
@@ -25,10 +25,10 @@ class GrpcAuthController {
 			let payload;
 			switch (type) {
 				case ETokenType.ACCESS:
-					payload = await JwtService.verifyAccessToken(token);
+					payload = await JwtService.verifyToken(token, "access");
 					break;
 				case ETokenType.ID:
-					payload = await JwtService.verifyIdToken(token);
+					payload = await JwtService.verifyToken(token, "id");
 					break;
 				default:
 					throw new BadRequestError(`Invalid token type: ${tokenType}`);

--- a/API/auth-service/src/services/JwtService.ts
+++ b/API/auth-service/src/services/JwtService.ts
@@ -1,7 +1,33 @@
 import { CognitoJwtVerifier } from "aws-jwt-verify";
 import CognitoClient from "../clients/CognitoIdentityProviderClient";
+import { SimpleJwksCache } from "aws-jwt-verify/jwk";
+import { SimpleFetcher } from "aws-jwt-verify/https";
 
 class JwtService {
+	public static async verifyToken(token: string, type: "id" | "access") {
+		const verifier = CognitoJwtVerifier.create(
+			{
+				userPoolId: CognitoClient.userPoolId,
+				tokenUse: type,
+				clientId: CognitoClient.clientId,
+			},
+			{
+				jwksCache: new SimpleJwksCache({
+					fetcher: new SimpleFetcher({
+						defaultRequestOptions: {
+							responseTimeout: 10000,
+						},
+					}),
+				}),
+			}
+		);
+		const payload = await verifier.verify(token);
+		return payload;
+	}
+
+	/**
+	 * @deprecated
+	 */
 	public static async verifyAccessToken(token: string) {
 		const verifier = CognitoJwtVerifier.create({
 			userPoolId: CognitoClient.userPoolId,
@@ -12,6 +38,9 @@ class JwtService {
 		return payload;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public static async verifyIdToken(token: string) {
 		const verifier = CognitoJwtVerifier.create({
 			userPoolId: CognitoClient.userPoolId,


### PR DESCRIPTION
merge verifyAccessToken and verifyIdToken into verifyToken

Fixed error `request timeout after 3000ms` when fetching AWS JWKs 

Testing:
Call localhost:3000/auth/verify with Bearer token header