### PR TITLE
Feat/accommodation service/count-accommodations-for-homepage

### DIFF
--- a/API/accommodation-service/src/controllers/accommodation.controller.ts
+++ b/API/accommodation-service/src/controllers/accommodation.controller.ts
@@ -52,6 +52,22 @@ export class AccommodationController {
 			next(error);
 		}
 	}
+
+	/**
+	 * GET /count
+	 * Query Params: ?city=...&type=...
+	 */
+	async getCount(req: Request, res: Response, next: NextFunction) {
+		try {
+			const { city, type } = req.query;
+
+			const result = await accommodationService.getCount(city as string | undefined, type as string | undefined);
+
+			sendSuccess(res, result);
+		} catch (error) {
+			next(error);
+		}
+	}
 }
 
 // Export a singleton instance of the controller

--- a/API/accommodation-service/src/repositories/accommodation.repository.ts
+++ b/API/accommodation-service/src/repositories/accommodation.repository.ts
@@ -1,5 +1,6 @@
 import prisma from "../prisma/client";
 //import { AccommodationEntity } from "../types/accommodation";
+import { Prisma, EAccommodationType } from "@prisma/client";
 
 export class AccommodationRepository {
 	async findById(id: string) {
@@ -46,6 +47,29 @@ export class AccommodationRepository {
 				},
 			},
 			take: 20, // <--- GIỚI HẠN: Chỉ lấy 20 thành phố cao nhất
+		});
+	}
+
+	// Count accommodations with city and type filters
+	async count(filters: { city?: string; type?: EAccommodationType }) {
+		const where: Prisma.AccommodationWhereInput = {
+			isActive: true,
+		};
+
+		if (filters.type) {
+			where.type = filters.type;
+		}
+
+		if (filters.city) {
+			where.address = {
+				city: {
+					contains: filters.city,
+				},
+			};
+		}
+
+		return prisma.accommodation.count({
+			where,
 		});
 	}
 }

--- a/API/accommodation-service/src/routes/accommodation.routes.ts
+++ b/API/accommodation-service/src/routes/accommodation.routes.ts
@@ -6,6 +6,9 @@ const router = Router();
 // GET /stats
 router.get("/stats", accommodationController.getHomepageStats.bind(accommodationController));
 
+// GET /count?city=...&type=...
+router.get("/count", accommodationController.getCount.bind(accommodationController));
+
 /**
  * GET /?byEntity=room&entityId=:roomId
  * Get accommodation details by Room ID.

--- a/API/accommodation-service/src/services/accommodation.service.ts
+++ b/API/accommodation-service/src/services/accommodation.service.ts
@@ -3,6 +3,7 @@ import { NotFoundError } from "../errors";
 //import { UserClient, RoomClient, ImageClient, ReviewClient } from "../clients";
 import { roomClient } from "../clients/room.client";
 import { imageClient } from "../clients/image.client";
+import { EAccommodationType } from "@prisma/client";
 
 export class AccommodationService {
 	async getAccommodationById(id: string, startDate?: string, endDate?: string) {
@@ -45,7 +46,7 @@ export class AccommodationService {
 	}
 
 	/**
-	 * Lấy thống kê cho trang chủ (Homepage)
+	 * Gets homepage statistics: popular accommodation types and cities.
 	 */
 	async getHomepageStats() {
 		console.log("[AccommodationService] Fetching homepage stats...");
@@ -65,6 +66,22 @@ export class AccommodationService {
 		return {
 			types: formattedTypes,
 			cities: formattedCities,
+		};
+	}
+
+	/**
+	 * Counts accommodations based on optional city and type filters.
+	 */
+	async getCount(city?: string, type?: string) {
+		const count = await accommodationRepository.count({
+			city: city,
+			type: type as EAccommodationType,
+		});
+
+		return {
+			city: city || null,
+			type: type || null,
+			count: count,
 		};
 	}
 }


### PR DESCRIPTION
## 📝 Description
PR này bổ sung endpoint `GET /accommodations/stats` phục vụ cho trang chủ (Homepage).
API này trả về dữ liệu thống kê số lượng cơ sở lưu trú (active) được nhóm theo **Loại hình** (Type) và **Thành phố** (City).

## 🛠 Changes
- **Repository**: Sử dụng Prisma `groupBy` để đếm số lượng (`_count`).
  - *Type*: Sắp xếp giảm dần (DESC).
  - *City*: Sắp xếp giảm dần (DESC) và giới hạn **Top 20** thành phố phổ biến nhất (`take: 20`).
- **Service**: Chạy song song 2 query bằng `Promise.all` và format lại dữ liệu trả về.
- **Controller**: Thêm method `getHomepageStats`.
- **Routes**: Đăng ký route `/stats`.

## 🔌 API Endpoint
**Request:**
`GET /accommodations/stats`

**Response (200 OK):**
```json
{
    "success": true,
    "data": {
        "types": [
            { "type": "HOTEL", "count": 15 },
            { "type": "VILLA", "count": 4 }
        ],
        "cities": [
            { "city": "Hồ Chí Minh", "count": 10 },
            { "city": "Đà Lạt", "count": 8 }
        ]
    },
    "error": null
}