### PR TITLE
fix(search-bar): update dropdown click function for search bar

### DIFF
--- a/UI/src/components/shared/HeroSearchBar.tsx
+++ b/UI/src/components/shared/HeroSearchBar.tsx
@@ -94,6 +94,17 @@ export const HeroSearchBar: React.FC = () => {
 		setGuests(criteria.guests);
 	}, [criteria.keyword, criteria.dates, criteria.guests]);
 
+	useEffect(() => {
+		function handleClickOutside(e: MouseEvent) {
+			if (refs.location.current && !refs.location.current.contains(e.target as Node)) {
+				handleToggleDropdown("location", false);
+			}
+		}
+
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => document.removeEventListener("mousedown", handleClickOutside);
+	}, []);
+
 	return (
 		<Box
 			ref={searchRef}


### PR DESCRIPTION
Issue: dropdown của location typeahead không tự biến mất khi người dùng click ra ngoài

Sửa bằng cách thêm useEffect vào