### PR TITLE
fix(detail-page): auto-correct check-out date if it is before check-in date

### DIFF
--- a/UI/src/features/accommodation/pages/DetailPage.tsx
+++ b/UI/src/features/accommodation/pages/DetailPage.tsx
@@ -49,6 +49,14 @@ export default function DetailPage() {
 		if (urlCheckIn && urlCheckOut) {
 			finalCheckIn = new Date(urlCheckIn);
 			finalCheckOut = new Date(urlCheckOut);
+			if (finalCheckOut <= finalCheckIn) {
+				// Tự động set Check-out = Check-in + 1 ngày
+				const correctedCheckOut = new Date(finalCheckIn);
+				correctedCheckOut.setDate(correctedCheckOut.getDate() + 1);
+
+				finalCheckOut = correctedCheckOut;
+				shouldUpdateUrl = true; // Cờ này bật lên để trigger cập nhật URL ở đoạn code dưới
+			}
 		} else {
 			const tomorrow = new Date();
 			tomorrow.setDate(tomorrow.getDate() + 1);


### PR DESCRIPTION
**What is the current behavior?**
Currently, when a user accesses the `DetailPage` via a deep link containing an invalid date range (where `checkOut` date is earlier than or equal to `checkIn` date), the system accepts these parameters as-is. This leads to:

* Incorrect calculation of "Nights" (0 or negative values).
* Potential errors when fetching room availability or processing payments.
* Confusing UI for the user.

**What is the new behavior?**
Added validation logic within the `useEffect` hook in `DetailPage.tsx`.

* The system now detects if `urlCheckOut <= urlCheckIn`.
* If invalid, it automatically corrects `checkOut` to be **1 day after** the `checkIn` date.
* The URL and Booking Context are updated immediately to reflect the valid range.