### PR TITLE
Enhancing Image Management in Owner Wizard

### DIFF
--- a/API/monolith-service/src/controllers/image.controller.ts
+++ b/API/monolith-service/src/controllers/image.controller.ts
@@ -1,6 +1,6 @@
-import { GetImagesRequest, ImageUploadMapper, type ImageEntityType, type UploadRequest } from "@/types/requests";
+import { DeleteImageRequest, GetImagesRequest, ImageUploadMapper, type ImageEntityType, type UploadRequest } from "@/types/requests";
 import type { ApiResponse, UploadResponse } from "@/types/responses";
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import ResponseHelper from "@/utils/response";
 import type { FileType, ImageFullInfo } from "@/types/image.types";
 import UploadService from "@/services/upload.service";
@@ -37,6 +37,12 @@ class ImageController {
 
 		const images = await this.#imageService.getImage(entityType, id);
 		return ResponseHelper.success(res, images);
+	}
+
+	public async delete(req: DeleteImageRequest, res: Response<ApiResponse<null>>) {
+		const id = req.params.id;
+		await this.#imageService.deleteImage(id);
+		return ResponseHelper.success(res, null);
 	}
 }
 

--- a/API/monolith-service/src/repositories/image.repository.ts
+++ b/API/monolith-service/src/repositories/image.repository.ts
@@ -92,4 +92,41 @@ export default class ImageRepository {
 			},
 		});
 	}
+
+	public async deleteEntityImages(entityType: EEntityType, entityId: string): Promise<string[]> {
+		const images = await this.#prisma.image.findMany({
+			where: {
+				references: {
+					some: {
+						entityId,
+						entityType,
+					},
+				},
+			},
+			include: {
+				variants: true,
+			},
+		});
+
+		if (images.length === 0) return [];
+
+		const s3Keys: string[] = [];
+		const imageIds: string[] = [];
+
+		for (const img of images) {
+			s3Keys.push(img.s3Key);
+			imageIds.push(img.id);
+			for (const variant of img.variants) {
+				s3Keys.push(variant.s3Key);
+			}
+		}
+
+		await this.#prisma.$transaction([
+			this.#prisma.imageVariant.deleteMany({ where: { imageId: { in: imageIds } } }),
+			this.#prisma.imageReference.deleteMany({ where: { imageId: { in: imageIds } } }),
+			this.#prisma.image.deleteMany({ where: { id: { in: imageIds } } }),
+		]);
+
+		return s3Keys;
+	}
 }

--- a/API/monolith-service/src/repositories/image.repository.ts
+++ b/API/monolith-service/src/repositories/image.repository.ts
@@ -93,6 +93,28 @@ export default class ImageRepository {
 		});
 	}
 
+	public async deleteImage(imageId: string): Promise<string[]> {
+		const image = await this.#prisma.image.findUnique({
+			where: { id: imageId },
+			include: { variants: true },
+		});
+
+		if (!image) return [];
+
+		const s3Keys: string[] = [image.s3Key];
+		for (const variant of image.variants) {
+			s3Keys.push(variant.s3Key);
+		}
+
+		await this.#prisma.$transaction([
+			this.#prisma.imageVariant.deleteMany({ where: { imageId } }),
+			this.#prisma.imageReference.deleteMany({ where: { imageId } }),
+			this.#prisma.image.delete({ where: { id: imageId } }),
+		]);
+
+		return s3Keys;
+	}
+
 	public async deleteEntityImages(entityType: EEntityType, entityId: string): Promise<string[]> {
 		const images = await this.#prisma.image.findMany({
 			where: {

--- a/API/monolith-service/src/routes/image.routes.ts
+++ b/API/monolith-service/src/routes/image.routes.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import ImageController from "@/controllers/image.controller";
-import type { GetImagesRequest, UploadRequest } from "../types/requests";
+import type { DeleteImageRequest, GetImagesRequest, UploadRequest } from "../types/requests";
 import multer from "multer";
 import { authMiddleware } from "@/middlewares/auth.middleware";
 
@@ -32,6 +32,11 @@ class ImageRouter {
 		this.router.get("/:type/:id", (req: Request, res: Response) => {
 			const request = req as unknown as GetImagesRequest;
 			return this.#imageController.getImages(request, res);
+		});
+
+		this.router.delete("/:id", authMiddleware, (req: Request, res: Response) => {
+			const request = req as unknown as DeleteImageRequest;
+			return this.#imageController.delete(request, res);
 		});
 	}
 }

--- a/API/monolith-service/src/services/image.service.ts
+++ b/API/monolith-service/src/services/image.service.ts
@@ -26,6 +26,13 @@ class ImageService {
 		return this._sanitizeImage(images);
 	}
 
+	async deleteImage(id: string) {
+		const keys = await this.#imageRepository.deleteImage(id);
+		if (keys.length > 0) {
+			await this.#s3Service.deleteFiles(keys);
+		}
+	}
+
 	async deleteImagesByEntity(type: EEntityType, id: string) {
 		const keys = await this.#imageRepository.deleteEntityImages(type, id);
 		if (keys.length > 0) {

--- a/API/monolith-service/src/services/image.service.ts
+++ b/API/monolith-service/src/services/image.service.ts
@@ -26,6 +26,13 @@ class ImageService {
 		return this._sanitizeImage(images);
 	}
 
+	async deleteImagesByEntity(type: EEntityType, id: string) {
+		const keys = await this.#imageRepository.deleteEntityImages(type, id);
+		if (keys.length > 0) {
+			await this.#s3Service.deleteFiles(keys);
+		}
+	}
+
 	_sanitizeImage(images: BaseImageInfo[]) {
 		const sanitizedImages = images.map((img) => ({
 			...img,

--- a/API/monolith-service/src/services/room.service.ts
+++ b/API/monolith-service/src/services/room.service.ts
@@ -152,7 +152,10 @@ export class RoomService {
 		const room = await this.getRoomById(roomId);
 		const deletedRoom = await this.#roomRepository.delete(roomId);
 
-		// 3. Clear Cache
+		// 3. Delete Images
+		await this.#imageService.deleteImagesByEntity(EEntityType.ROOM, roomId);
+
+		// 4. Clear Cache
 		await redisClient.del(`${this.CACHE_PREFIX}${room.accommodationId}`);
 
 		return deletedRoom;

--- a/API/monolith-service/src/services/s3.service.ts
+++ b/API/monolith-service/src/services/s3.service.ts
@@ -1,4 +1,4 @@
-import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { PutObjectCommand, DeleteObjectsCommand } from "@aws-sdk/client-s3";
 import { EEntityType, EVariantType } from "@/generated/enums";
 import S3ClientSingleton from "@/clients/s3.client";
 import { type ImageProcessingResultKey, type UploadResult, type UploadResultProperties } from "@/types/image.types";
@@ -18,6 +18,31 @@ export default class S3Service {
 				ACL: "public-read",
 			})
 		);
+	}
+
+	public async deleteFiles(keys: string[]) {
+		if (keys.length === 0) return;
+
+		const CHUNK_SIZE = 1000;
+		const deletePromises = [];
+
+		for (let i = 0; i < keys.length; i += CHUNK_SIZE) {
+			const chunk = keys.slice(i, i + CHUNK_SIZE);
+
+			const promise = this.s3Client.send(
+				new DeleteObjectsCommand({
+					Bucket: this.bucket,
+					Delete: {
+						Objects: chunk.map((key) => ({ Key: key })),
+						Quiet: true,
+					},
+				})
+			);
+
+			deletePromises.push(promise);
+		}
+
+		await Promise.all(deletePromises);
 	}
 
 	private async uploadVariant(baseKey: string, buffer: Buffer, variantName: ImageProcessingResultKey, mimeType: string) {

--- a/API/monolith-service/src/types/requests/image.request.ts
+++ b/API/monolith-service/src/types/requests/image.request.ts
@@ -23,3 +23,9 @@ export interface GetImageRequestType {
 }
 
 export type GetImagesRequest = Request<GetImageRequestType>;
+
+export interface DeleteImageRequestType {
+	id: string;
+}
+
+export type DeleteImageRequest = Request<DeleteImageRequestType>;

--- a/UI/src/features/owner/components/Wizard/Step5/StepRoomBox.tsx
+++ b/UI/src/features/owner/components/Wizard/Step5/StepRoomBox.tsx
@@ -4,6 +4,7 @@ import AddIcon from "@mui/icons-material/Add";
 import type { RoomForm, AmenityConfigForm, WizardForm, UpdateRoomDTO, RoomSummary } from "../../../types/owner.types";
 import { makeRoom, makeBed, toEViewType, toEPricingType, toEBedType, toEBedSize } from "../../../const/RoomConst";
 import { useCreateRoom, useUpdateRoom } from "../../../hooks/useCreateAndUpdateRoom";
+import { useDeleteRoom } from "../../../hooks/useDeleteRoom";
 import RoomCard from "./RoomCard";
 import RoomEditModal from "./RoomEditModal";
 import RoomInfoFields from "./RoomInfoField";
@@ -68,17 +69,39 @@ export default function StepRoomsBox({ form, setForm, triggerSave, onSaveComplet
 	const [draftAmenities, setDraftAmenities] = useState<AmenityConfigForm[]>([]);
 
 	const createMutation = useCreateRoom(accommodationId);
+	const deleteMutation = useDeleteRoom(accommodationId);
 
 	const activeId = isEntirePlace ? inlineRoom.id : editingRoom?.id;
 	const hasPersisted = isRealServerId(activeId);
 	const updateMutation = useUpdateRoom(accommodationId, hasPersisted ? activeId! : "");
 
-	const apiError = createMutation.error?.message ?? updateMutation.error?.message ?? null;
+	const apiError = createMutation.error?.message ?? updateMutation.error?.message ?? deleteMutation.error?.message ?? null;
 
 	const stateRef = useRef({ inlineRoom, inlineAmenities });
 	useEffect(() => {
 		stateRef.current = { inlineRoom, inlineAmenities };
 	}, [inlineRoom, inlineAmenities]);
+
+	const handleDeleteRoom = (roomId?: string) => {
+		if (!roomId) return;
+
+		const removeLocal = () => {
+			setForm((p) => ({
+				...p,
+				rooms: p.rooms.filter((r) => r.id !== roomId),
+				// Also remove associated images from local state
+				images: p.images.filter((img) => img.roomId !== roomId),
+			}));
+		};
+
+		if (isRealServerId(roomId)) {
+			deleteMutation.mutate(roomId, {
+				onSuccess: removeLocal,
+			});
+		} else {
+			removeLocal();
+		}
+	};
 
 	// ── AUTO-SAVE EFFECT (ENTIRE PLACE) ──
 	useEffect(() => {
@@ -194,7 +217,7 @@ export default function StepRoomsBox({ form, setForm, triggerSave, onSaveComplet
 								setEditingRoom(room);
 								setDraftAmenities(room.amenities);
 							}}
-							onDelete={() => setForm((p) => ({ ...p, rooms: p.rooms.filter((r) => r.id !== room.id) }))}
+							onDelete={() => handleDeleteRoom(room.id)}
 						/>
 					))}
 				</Stack>

--- a/UI/src/features/owner/components/Wizard/Step6/ImageUploader.tsx
+++ b/UI/src/features/owner/components/Wizard/Step6/ImageUploader.tsx
@@ -1,0 +1,216 @@
+import React, { useRef } from "react";
+import { Box, Typography, IconButton, Paper } from "@mui/material";
+import { CloudUpload as CloudUploadIcon, Close as CloseIcon, Add as AddIcon } from "@mui/icons-material";
+import type { ImageItem } from "../../../types/owner.types";
+
+interface ImageUploaderProps {
+	title?: string;
+	description?: string;
+	images: ImageItem[];
+	onAdd: (files: File[]) => void;
+	onRemove: (id: string) => void;
+}
+
+export default function ImageUploader({ title, description, images, onAdd, onRemove }: ImageUploaderProps) {
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		if (event.target.files && event.target.files.length > 0) {
+			onAdd(Array.from(event.target.files));
+		}
+	};
+
+	const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		if (event.dataTransfer.files && event.dataTransfer.files.length > 0) {
+			onAdd(Array.from(event.dataTransfer.files));
+		}
+	};
+
+	const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+		event.preventDefault();
+	};
+
+	const triggerFileInput = () => {
+		fileInputRef.current?.click();
+	};
+
+	if (images.length === 0) {
+		return (
+			<Box>
+				{title && (
+					<Typography variant="h6" gutterBottom>
+						{title}
+					</Typography>
+				)}
+				{description && (
+					<Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+						{description}
+					</Typography>
+				)}
+
+				<Paper
+					variant="outlined"
+					sx={{
+						p: 6,
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						justifyContent: "center",
+						borderStyle: "dashed",
+						borderWidth: 2,
+						borderColor: "rgba(255,255,255,0.2)",
+						backgroundColor: "rgba(255,255,255,0.02)",
+						cursor: "pointer",
+						transition: "all 0.2s ease-in-out",
+						"&:hover": {
+							borderColor: "primary.main",
+							backgroundColor: "rgba(245,166,35,0.05)",
+						},
+					}}
+					onClick={triggerFileInput}
+					onDrop={handleDrop}
+					onDragOver={handleDragOver}
+				>
+					<CloudUploadIcon sx={{ fontSize: 48, color: "text.secondary", mb: 2 }} />
+					<Typography variant="h6" align="center" gutterBottom>
+						Drag & drop your property images here
+					</Typography>
+					<Typography variant="body2" color="text.secondary" align="center">
+						or click to browse from your computer
+					</Typography>
+					<input type="file" multiple accept="image/*" hidden ref={fileInputRef} onChange={handleFileChange} />
+				</Paper>
+			</Box>
+		);
+	}
+
+	return (
+		<Box>
+			{title && (
+				<Typography variant="h6" gutterBottom>
+					{title}
+				</Typography>
+			)}
+			{description && (
+				<Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+					{description}
+				</Typography>
+			)}
+
+			<Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))", gap: 2 }}>
+				{images.map((img) => (
+					<Box
+						key={img.id}
+						sx={{
+							position: "relative",
+							paddingTop: "100%", // 1:1 Aspect Ratio
+							borderRadius: 2,
+							overflow: "hidden",
+							boxShadow: 3,
+							// border: index === 0 ? "2px solid" : "none", // Logic for cover image can be improved
+							// borderColor: "primary.main",
+						}}
+					>
+						<img
+							src={img.url || (img.file ? URL.createObjectURL(img.file) : "")}
+							alt="Uploaded"
+							style={{
+								position: "absolute",
+								top: 0,
+								left: 0,
+								width: "100%",
+								height: "100%",
+								objectFit: "cover",
+							}}
+						/>
+
+						{/* Cover Image Badge - for now we can say the first accommodation image is cover */}
+						{/* {index === 0 && (
+							<Box
+								sx={{
+									position: "absolute",
+									bottom: 0,
+									left: 0,
+									right: 0,
+									backgroundColor: "rgba(0,0,0,0.7)",
+									color: "white",
+									py: 0.5,
+									textAlign: "center",
+									fontSize: "0.75rem",
+									fontWeight: "bold",
+								}}
+							>
+								COVER IMAGE
+							</Box>
+						)} */}
+
+						{/* Remove Button */}
+						<IconButton
+							size="small"
+							onClick={() => onRemove(img.id)}
+							sx={{
+								position: "absolute",
+								top: 4,
+								right: 4,
+								backgroundColor: "rgba(0,0,0,0.5)",
+								color: "white",
+								"&:hover": {
+									backgroundColor: "rgba(244, 67, 54, 0.8)",
+								},
+							}}
+						>
+							<CloseIcon fontSize="small" />
+						</IconButton>
+					</Box>
+				))}
+
+				{/* Small Add More Tile */}
+				<Paper
+					variant="outlined"
+					sx={{
+						position: "relative",
+						paddingTop: "100%", // 1:1 Aspect Ratio
+						borderRadius: 2,
+						borderStyle: "dashed",
+						borderWidth: 2,
+						borderColor: "rgba(255,255,255,0.2)",
+						backgroundColor: "rgba(255,255,255,0.02)",
+						cursor: "pointer",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						transition: "all 0.2s ease-in-out",
+						"&:hover": {
+							borderColor: "primary.main",
+							backgroundColor: "rgba(245,166,35,0.05)",
+						},
+					}}
+					onClick={triggerFileInput}
+					onDrop={handleDrop}
+					onDragOver={handleDragOver}
+				>
+					<Box
+						sx={{
+							position: "absolute",
+							top: 0,
+							left: 0,
+							right: 0,
+							bottom: 0,
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+							justifyContent: "center",
+						}}
+					>
+						<AddIcon sx={{ fontSize: 32, color: "text.secondary", mb: 1 }} />
+						<Typography variant="body2" color="text.secondary" fontWeight="bold">
+							Add more
+						</Typography>
+					</Box>
+					<input type="file" multiple accept="image/*" hidden ref={fileInputRef} onChange={handleFileChange} />
+				</Paper>
+			</Box>
+		</Box>
+	);
+}

--- a/UI/src/features/owner/components/Wizard/Step6/StepImageBox.tsx
+++ b/UI/src/features/owner/components/Wizard/Step6/StepImageBox.tsx
@@ -1,111 +1,100 @@
-import { Box, Typography, Paper } from "@mui/material";
-import { useCallback } from "react";
+import { Box, Typography, Paper, Container, Accordion, AccordionSummary, AccordionDetails, Divider } from "@mui/material";
+import { useState, useEffect } from "react";
+import type { WizardForm } from "../../../types/owner.types";
+import { ExpandMore as ExpandMoreIcon, PhotoLibrary as PhotoLibraryIcon, MeetingRoom as MeetingRoomIcon } from "@mui/icons-material";
+import ImageUploader from "./ImageUploader";
 
-type Props = {
-	form: any;
-};
+interface Props {
+	form: WizardForm;
+	setForm: React.Dispatch<React.SetStateAction<WizardForm>>;
+	onFieldChange?: () => void;
+	triggerSubmit: boolean;
+	resetTrigger: () => void;
+	onSuccess: () => void;
+}
 
-const StepImageBox = ({ form }: Props) => {
-	// ─── Utils ─────────────────────────────────────────────
+const StepImageBox = ({ form, setForm, onFieldChange, triggerSubmit, resetTrigger, onSuccess }: Props) => {
+	const rooms = form.rooms;
 
-	const chunkFiles = (files: File[], size = 10) => {
-		const chunks: File[][] = [];
-		for (let i = 0; i < files.length; i += size) {
-			chunks.push(files.slice(i, i + size));
-		}
-		return chunks;
+	const [expandedAccordion, setExpandedAccordion] = useState<string | false>(false);
+
+	const handleAccordionChange = (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
+		setExpandedAccordion(isExpanded ? panel : false);
 	};
 
-	const uploadImages = async (url: string, files: File[]) => {
-		const chunks = chunkFiles(files, 10);
-
-		for (const chunk of chunks) {
-			const formData = new FormData();
-
-			chunk.forEach((file) => {
-				formData.append("files", file);
-			});
-
-			await fetch(url, {
-				method: "POST",
-				body: formData,
-			});
+	// Handle submission trigger to advance to the next step
+	useEffect(() => {
+		if (triggerSubmit) {
+			// TODO: Implement actual image upload logic using ownerApi here
+			resetTrigger();
+			onSuccess();
 		}
-	};
-
-	// ─── Drop handlers ─────────────────────────────────────
-
-	const handleAccommodationDrop = useCallback(
-		async (e: React.DragEvent) => {
-			e.preventDefault();
-
-			const files = Array.from(e.dataTransfer.files);
-
-			if (!form.accommodationId) {
-				alert("Accommodation must be created first.");
-				return;
-			}
-
-			await uploadImages(`/images/accommodation/${form.accommodationId}`, files);
-		},
-		[form.accommodationId]
-	);
-
-	const handleRoomDrop = useCallback(async (e: React.DragEvent, roomId: string) => {
-		e.preventDefault();
-
-		const files = Array.from(e.dataTransfer.files);
-
-		await uploadImages(`/images/room/${roomId}`, files);
-	}, []);
-
-	// ─── UI ────────────────────────────────────────────────
+	}, [triggerSubmit, resetTrigger, onSuccess]);
 
 	return (
-		<Box>
-			<Typography variant="h6" fontWeight={700} mb={2}>
-				Upload Images
-			</Typography>
-
-			{/* ── Accommodation Upload ───────────────── */}
+		<Container maxWidth="md" sx={{ py: 6 }}>
 			<Paper
-				onDrop={handleAccommodationDrop}
-				onDragOver={(e) => e.preventDefault()}
+				elevation={0}
 				sx={{
-					p: 4,
-					border: "2px dashed",
-					borderColor: "primary.main",
-					borderRadius: 3,
-					textAlign: "center",
-					mb: 4,
-					cursor: "pointer",
+					p: { xs: 3, md: 5 },
+					borderRadius: 4,
+					backgroundColor: "background.paper",
+					border: "1px solid rgba(255,255,255,0.08)",
+					boxShadow: "0 8px 32px rgba(0,0,0,0.2)",
 				}}
 			>
-				<Typography fontWeight={600}>Drop images for main property here</Typography>
-				<Typography variant="caption">(Max 10 per request — auto chunked)</Typography>
-			</Paper>
+				<Box sx={{ mb: 6 }}>
+					<Typography variant="h4" component="h1" gutterBottom>
+						Property Photos
+					</Typography>
+					<Typography variant="body1" color="text.secondary">
+						Great photos invite guests in. Upload high-quality images of your property's exterior, common areas, and specific rooms.
+					</Typography>
+				</Box>
 
-			{/* ── Room Uploads ───────────────────────── */}
-			{form.rooms.map((room: any) => (
-				<Paper
-					key={room.id}
-					onDrop={(e) => handleRoomDrop(e, room.id)}
-					onDragOver={(e) => e.preventDefault()}
-					sx={{
-						p: 3,
-						border: "2px dashed",
-						borderColor: "divider",
-						borderRadius: 3,
-						textAlign: "center",
-						mb: 2,
-						cursor: "pointer",
-					}}
-				>
-					<Typography fontWeight={600}>Room: {room.name || room.id}</Typography>
-					<Typography variant="caption">Drop room images here</Typography>
-				</Paper>
-			))}
-		</Box>
+				{/* Section 1: General Accommodation Gallery */}
+				<Box sx={{ mb: 6 }}>
+					<Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
+						<PhotoLibraryIcon sx={{ mr: 1.5, color: "primary.main" }} />
+						<Typography variant="h5" component="h2">
+							General Property Photos
+						</Typography>
+					</Box>
+
+					<Box sx={{ p: 3, backgroundColor: "rgba(0,0,0,0.2)", borderRadius: 3, border: "1px solid rgba(255,255,255,0.03)" }}>
+						<ImageUploader title="Facade, Lobby & Amenities" description="Upload photos of the building exterior, reception, pool, gym, or restaurant." />
+					</Box>
+				</Box>
+
+				<Divider sx={{ my: 6, borderColor: "rgba(255,255,255,0.1)" }} />
+
+				{/* Section 2: Room-Specific Galleries */}
+				<Box sx={{ mb: 2 }}>
+					<Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
+						<MeetingRoomIcon sx={{ mr: 1.5, color: "secondary.main" }} />
+						<Typography variant="h5" component="h2">
+							Room-Specific Photos
+						</Typography>
+					</Box>
+					<Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+						Upload photos for each room type you offer. Guests want to see exactly where they will be sleeping.
+					</Typography>
+
+					{rooms.map((room, idx) => (
+						<Accordion key={room.id} expanded={expandedAccordion === room.id} onChange={handleAccordionChange(idx.toString())} disableGutters elevation={0}>
+							<AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "text.secondary" }} />} sx={{ px: 3, py: 1 }}>
+								<Typography variant="h6" sx={{ fontSize: "1.1rem" }}>
+									{room.name}
+								</Typography>
+							</AccordionSummary>
+							<AccordionDetails sx={{ px: 3, pb: 4, pt: 1 }}>
+								<ImageUploader description={room.description} />
+							</AccordionDetails>
+						</Accordion>
+					))}
+				</Box>
+			</Paper>
+		</Container>
 	);
 };
 

--- a/UI/src/features/owner/components/Wizard/Step6/StepImageBox.tsx
+++ b/UI/src/features/owner/components/Wizard/Step6/StepImageBox.tsx
@@ -1,8 +1,19 @@
-import { Box, Typography, Paper, Container, Accordion, AccordionSummary, AccordionDetails, Divider } from "@mui/material";
+import { Box, Typography, Paper, Container, Accordion, AccordionSummary, AccordionDetails, Divider, CircularProgress } from "@mui/material";
 import { useState, useEffect } from "react";
-import type { WizardForm } from "../../../types/owner.types";
+import type { WizardForm, ImageItem } from "../../../types/owner.types";
 import { ExpandMore as ExpandMoreIcon, PhotoLibrary as PhotoLibraryIcon, MeetingRoom as MeetingRoomIcon } from "@mui/icons-material";
 import ImageUploader from "./ImageUploader";
+import { useUploadImages } from "../../../hooks/useUploadImages";
+import { useGetImages } from "../../../hooks/useGetImages";
+
+interface Props {
+	form: WizardForm;
+	setForm: React.Dispatch<React.SetStateAction<WizardForm>>;
+	onFieldChange?: () => void;
+	triggerSubmit: boolean;
+	resetTrigger: () => void;
+	onSuccess: () => void;
+}
 
 interface Props {
 	form: WizardForm;
@@ -14,87 +25,198 @@ interface Props {
 }
 
 const StepImageBox = ({ form, setForm, onFieldChange, triggerSubmit, resetTrigger, onSuccess }: Props) => {
-	const rooms = form.rooms;
-
+	const [isUploading, setIsUploading] = useState(false);
 	const [expandedAccordion, setExpandedAccordion] = useState<string | false>(false);
+	const { mutateAsync: uploadImages } = useUploadImages();
 
-	const handleAccordionChange = (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
+	const roomIds = form.rooms.map((r) => r.id).filter(Boolean) as string[];
+	const { data: dbImages, isLoading: isFetching } = useGetImages(form.accommodationId, roomIds);
+
+	// 1. FIXED MERGE LOGIC
+	useEffect(() => {
+		if (!dbImages) return;
+
+		setForm((prev) => {
+			// Get only the local files that haven't been uploaded to the DB yet
+			const localOnly = prev.images.filter((img) => !!img.file);
+
+			// Combine DB images with local files.
+			// We don't need to check IDs because DB images won't have the 'file' property
+			return {
+				...prev,
+				images: [...dbImages, ...localOnly],
+			};
+		});
+	}, [dbImages, setForm]);
+
+	const handleAccordionChange = (panel: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
 		setExpandedAccordion(isExpanded ? panel : false);
 	};
 
-	// Handle submission trigger to advance to the next step
+	const handleAddImages = (target: "accommodation" | "room", roomId?: string, roomTempId?: string) => (files: File[]) => {
+		const newImages: ImageItem[] = files.map((file) => ({
+			id: crypto.randomUUID(), // This is fine for local tracking
+			file,
+			target,
+			roomId,
+			roomTempId,
+		}));
+
+		setForm((prev) => ({
+			...prev,
+			images: [...prev.images, ...newImages],
+		}));
+		onFieldChange?.();
+	};
+
+	const handleRemoveImage = (id: string) => {
+		// NOTE: If the user removes a DB image, you might need a separate API call to delete it from the server!
+		setForm((prev) => ({
+			...prev,
+			images: prev.images.filter((img) => img.id !== id),
+		}));
+		onFieldChange?.();
+	};
+
+	// 2. FIXED UPLOAD LOGIC
 	useEffect(() => {
 		if (triggerSubmit) {
-			// TODO: Implement actual image upload logic using ownerApi here
-			resetTrigger();
-			onSuccess();
+			const performUpload = async () => {
+				setIsUploading(true);
+				try {
+					// Filter out DB images so we only upload new files
+					const imagesToUpload = form.images.filter((img) => !!img.file);
+
+					if (form.accommodationId && imagesToUpload.length > 0) {
+						await uploadImages({
+							accommodationId: form.accommodationId,
+							images: imagesToUpload,
+						});
+					}
+					onSuccess();
+				} catch (error) {
+					console.error("Upload failed", error);
+				} finally {
+					setIsUploading(false);
+					resetTrigger();
+				}
+			};
+
+			performUpload();
 		}
-	}, [triggerSubmit, resetTrigger, onSuccess]);
+	}, [triggerSubmit]); // Removed aggressive dependencies that could cause multi-renders
+
+	if (isFetching && form.images.length === 0) {
+		return (
+			<Box display="flex" justifyContent="center" py={6}>
+				<CircularProgress />
+			</Box>
+		);
+	}
 
 	return (
-		<Container maxWidth="md" sx={{ py: 6 }}>
-			<Paper
-				elevation={0}
-				sx={{
-					p: { xs: 3, md: 5 },
-					borderRadius: 4,
-					backgroundColor: "background.paper",
-					border: "1px solid rgba(255,255,255,0.08)",
-					boxShadow: "0 8px 32px rgba(0,0,0,0.2)",
-				}}
-			>
-				<Box sx={{ mb: 6 }}>
-					<Typography variant="h4" component="h1" gutterBottom>
+		<Box sx={{ position: "relative" }}>
+			{isUploading && (
+				<Box
+					sx={{
+						position: "absolute",
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						bgcolor: "rgba(0,0,0,0.5)",
+						zIndex: 10,
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						borderRadius: 4,
+					}}
+				>
+					<CircularProgress />
+				</Box>
+			)}
+
+			<Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={4}>
+				<Box>
+					<Typography variant="h5" fontWeight={800} mb={1} color="primary">
 						Property Photos
 					</Typography>
-					<Typography variant="body1" color="text.secondary">
+					<Typography variant="body2" color="text.secondary">
 						Great photos invite guests in. Upload high-quality images of your property's exterior, common areas, and specific rooms.
 					</Typography>
 				</Box>
+			</Box>
 
-				{/* Section 1: General Accommodation Gallery */}
-				<Box sx={{ mb: 6 }}>
-					<Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
-						<PhotoLibraryIcon sx={{ mr: 1.5, color: "primary.main" }} />
-						<Typography variant="h5" component="h2">
-							General Property Photos
-						</Typography>
-					</Box>
-
-					<Box sx={{ p: 3, backgroundColor: "rgba(0,0,0,0.2)", borderRadius: 3, border: "1px solid rgba(255,255,255,0.03)" }}>
-						<ImageUploader title="Facade, Lobby & Amenities" description="Upload photos of the building exterior, reception, pool, gym, or restaurant." />
-					</Box>
-				</Box>
-
-				<Divider sx={{ my: 6, borderColor: "rgba(255,255,255,0.1)" }} />
-
-				{/* Section 2: Room-Specific Galleries */}
-				<Box sx={{ mb: 2 }}>
-					<Box sx={{ display: "flex", alignItems: "center", mb: 3 }}>
-						<MeetingRoomIcon sx={{ mr: 1.5, color: "secondary.main" }} />
-						<Typography variant="h5" component="h2">
-							Room-Specific Photos
-						</Typography>
-					</Box>
-					<Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-						Upload photos for each room type you offer. Guests want to see exactly where they will be sleeping.
+			{/* Section 1: General Accommodation Gallery */}
+			<Box sx={{ mb: 4 }}>
+				<Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+					<PhotoLibraryIcon sx={{ mr: 1, color: "primary.main" }} />
+					<Typography variant="subtitle1" fontWeight={700}>
+						General Property Photos
 					</Typography>
-
-					{rooms.map((room, idx) => (
-						<Accordion key={room.id} expanded={expandedAccordion === room.id} onChange={handleAccordionChange(idx.toString())} disableGutters elevation={0}>
-							<AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "text.secondary" }} />} sx={{ px: 3, py: 1 }}>
-								<Typography variant="h6" sx={{ fontSize: "1.1rem" }}>
-									{room.name}
-								</Typography>
-							</AccordionSummary>
-							<AccordionDetails sx={{ px: 3, pb: 4, pt: 1 }}>
-								<ImageUploader description={room.description} />
-							</AccordionDetails>
-						</Accordion>
-					))}
 				</Box>
-			</Paper>
-		</Container>
+
+				<Box sx={{ p: 2, backgroundColor: "action.hover", borderRadius: 2, border: "1px solid", borderColor: "divider" }}>
+					<ImageUploader
+						title="Facade, Lobby & Amenities"
+						description="Upload photos of the building exterior, reception, pool, gym, or restaurant."
+						images={form.images.filter((img) => img.target === "accommodation")}
+						onAdd={handleAddImages("accommodation")}
+						onRemove={handleRemoveImage}
+					/>
+				</Box>
+			</Box>
+
+			<Divider sx={{ my: 4 }} />
+
+			{/* Section 2: Room-Specific Galleries */}
+			<Box>
+				<Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+					<MeetingRoomIcon sx={{ mr: 1, color: "secondary.main" }} />
+					<Typography variant="subtitle1" fontWeight={700}>
+						Room-Specific Photos
+					</Typography>
+				</Box>
+				<Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+					Upload photos for each room type you offer. Guests want to see exactly where they will be sleeping.
+				</Typography>
+
+				{form.rooms.map((room) => (
+					<Accordion
+						key={room.id || room.tempId}
+						expanded={expandedAccordion === (room.id || room.tempId)}
+						onChange={handleAccordionChange(room.id || room.tempId)}
+						disableGutters
+						elevation={0}
+						sx={{
+							mb: 1.5,
+							border: "1px solid",
+							borderColor: "divider",
+							borderRadius: "8px !important",
+							overflow: "hidden",
+							"&:before": { display: "none" },
+						}}
+					>
+						<AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: "text.secondary" }} />} sx={{ px: 2, py: 0.5, bgcolor: "action.hover" }}>
+							<Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+								{room.name}
+							</Typography>
+							<Typography variant="caption" sx={{ ml: 2, color: "text.secondary", alignSelf: "center" }}>
+								{form.images.filter((img) => img.target === "room" && (img.roomId === room.id || img.roomTempId === room.tempId)).length} photos
+							</Typography>
+						</AccordionSummary>
+						<AccordionDetails sx={{ p: 2 }}>
+							<ImageUploader
+								description={room.description}
+								images={form.images.filter((img) => img.target === "room" && (img.roomId === room.id || img.roomTempId === room.tempId))}
+								onAdd={handleAddImages("room", room.id, room.tempId)}
+								onRemove={handleRemoveImage}
+							/>
+						</AccordionDetails>
+					</Accordion>
+				))}
+			</Box>
+		</Box>
 	);
 };
 

--- a/UI/src/features/owner/components/Wizard/Step6/StepImageBox.tsx
+++ b/UI/src/features/owner/components/Wizard/Step6/StepImageBox.tsx
@@ -1,10 +1,11 @@
-import { Box, Typography, Paper, Container, Accordion, AccordionSummary, AccordionDetails, Divider, CircularProgress } from "@mui/material";
+import { Box, Typography, Accordion, AccordionSummary, AccordionDetails, Divider, CircularProgress } from "@mui/material";
 import { useState, useEffect } from "react";
 import type { WizardForm, ImageItem } from "../../../types/owner.types";
 import { ExpandMore as ExpandMoreIcon, PhotoLibrary as PhotoLibraryIcon, MeetingRoom as MeetingRoomIcon } from "@mui/icons-material";
 import ImageUploader from "./ImageUploader";
 import { useUploadImages } from "../../../hooks/useUploadImages";
 import { useGetImages } from "../../../hooks/useGetImages";
+import { useDeleteImage } from "../../../hooks/useDeleteImage";
 
 interface Props {
 	form: WizardForm;
@@ -28,6 +29,7 @@ const StepImageBox = ({ form, setForm, onFieldChange, triggerSubmit, resetTrigge
 	const [isUploading, setIsUploading] = useState(false);
 	const [expandedAccordion, setExpandedAccordion] = useState<string | false>(false);
 	const { mutateAsync: uploadImages } = useUploadImages();
+	const { mutateAsync: deleteImage } = useDeleteImage();
 
 	const roomIds = form.rooms.map((r) => r.id).filter(Boolean) as string[];
 	const { data: dbImages, isLoading: isFetching } = useGetImages(form.accommodationId, roomIds);
@@ -69,8 +71,19 @@ const StepImageBox = ({ form, setForm, onFieldChange, triggerSubmit, resetTrigge
 		onFieldChange?.();
 	};
 
-	const handleRemoveImage = (id: string) => {
-		// NOTE: If the user removes a DB image, you might need a separate API call to delete it from the server!
+	const handleRemoveImage = async (id: string) => {
+		const imageToRemove = form.images.find((img) => img.id === id);
+
+		if (imageToRemove && !imageToRemove.file) {
+			// This is a DB image, delete it from server
+			try {
+				await deleteImage(id);
+			} catch (error) {
+				console.error("Failed to delete image from server", error);
+				return;
+			}
+		}
+
 		setForm((prev) => ({
 			...prev,
 			images: prev.images.filter((img) => img.id !== id),

--- a/UI/src/features/owner/components/Wizard/Step7/StepPreviewBox.tsx
+++ b/UI/src/features/owner/components/Wizard/Step7/StepPreviewBox.tsx
@@ -1,0 +1,125 @@
+import { Box, Typography, Paper, Grid, Divider, Chip } from "@mui/material";
+import type { WizardForm } from "../../../types/owner.types";
+import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
+import MeetingRoomOutlinedIcon from "@mui/icons-material/MeetingRoomOutlined";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ImageList from "@mui/material/ImageList";
+import ImageListItem from "@mui/material/ImageListItem";
+
+interface Props {
+	form: WizardForm;
+}
+
+const StepPreviewBox = ({ form }: Props) => {
+	const coverImage = form.images.find((img) => img.target === "accommodation");
+
+	return (
+		<Box>
+			<Typography variant="h5" fontWeight={800} mb={1} color="primary">
+				Review Your Listing
+			</Typography>
+			<Typography variant="body2" color="text.secondary" mb={4}>
+				Please review the details below. Once you publish, your accommodation will be live for bookings.
+			</Typography>
+
+			<Grid container spacing={4}>
+				{/* Left Column: Basic Info & Facilities */}
+				<Grid item xs={12} md={7}>
+					<Paper elevation={0} sx={{ p: 3, mb: 3, borderRadius: 3, border: "1px solid", borderColor: "divider" }}>
+						<Typography variant="h6" fontWeight={700} mb={2}>
+							{form.name || "Unnamed Property"}
+						</Typography>
+						<Box display="flex" alignItems="center" gap={1} mb={2} color="text.secondary">
+							<LocationOnOutlinedIcon fontSize="small" />
+							<Typography variant="body2">{form.address.fullAddress || "No address provided"}</Typography>
+						</Box>
+
+						<Box display="flex" gap={1} mb={3}>
+							<Chip label={form.rentalType.replace(/_/g, " ")} color="primary" size="small" />
+							<Chip label={form.accommodationType} variant="outlined" size="small" />
+						</Box>
+
+						<Typography variant="body2" sx={{ whiteSpace: "pre-line", mb: 3 }}>
+							{form.description}
+						</Typography>
+
+						<Divider sx={{ my: 2 }} />
+
+						<Typography variant="subtitle1" fontWeight={700} mb={1.5}>
+							Facilities
+						</Typography>
+						<Box display="flex" flexWrap="wrap" gap={1}>
+							{form.facilities.map((fac) => (
+								<Chip key={fac.id} icon={<CheckCircleOutlineIcon />} label={fac.name} size="small" variant="outlined" />
+							))}
+							{form.facilities.length === 0 && (
+								<Typography variant="body2" color="text.secondary">
+									No facilities added.
+								</Typography>
+							)}
+						</Box>
+					</Paper>
+
+					{/* Rooms Summary */}
+					<Paper elevation={0} sx={{ p: 3, borderRadius: 3, border: "1px solid", borderColor: "divider" }}>
+						<Typography variant="subtitle1" fontWeight={700} mb={2} display="flex" alignItems="center" gap={1}>
+							<MeetingRoomOutlinedIcon color="primary" /> Rooms ({form.rooms.length})
+						</Typography>
+
+						{form.rooms.map((room, idx) => (
+							<Box key={room.tempId || idx} mb={idx < form.rooms.length - 1 ? 2 : 0}>
+								<Typography variant="subtitle2" fontWeight={600}>
+									{room.name}
+								</Typography>
+								<Typography variant="caption" color="text.secondary" display="block">
+									{room.maxAdults} Adults · {room.maxChildren} Children · {room.bedroomCount} Bedrooms
+								</Typography>
+								{idx < form.rooms.length - 1 && <Divider sx={{ mt: 2 }} />}
+							</Box>
+						))}
+					</Paper>
+				</Grid>
+
+				{/* Right Column: Images */}
+				<Grid item xs={12} md={5}>
+					<Paper elevation={0} sx={{ p: 2, borderRadius: 3, border: "1px solid", borderColor: "divider", height: "100%" }}>
+						<Typography variant="subtitle1" fontWeight={700} mb={2}>
+							Images ({form.images.length})
+						</Typography>
+
+						{coverImage ? (
+							<Box sx={{ width: "100%", height: 200, borderRadius: 2, overflow: "hidden", mb: 2 }}>
+								<img
+									src={coverImage.url || (coverImage.file ? URL.createObjectURL(coverImage.file) : "")}
+									alt="Cover"
+									style={{ width: "100%", height: "100%", objectFit: "cover" }}
+								/>
+							</Box>
+						) : (
+							<Box sx={{ width: "100%", height: 200, borderRadius: 2, bgcolor: "action.hover", display: "flex", alignItems: "center", justifyContent: "center", mb: 2 }}>
+								<Typography variant="body2" color="text.secondary">
+									No cover image
+								</Typography>
+							</Box>
+						)}
+
+						<ImageList sx={{ width: "100%", height: 300 }} cols={3} rowHeight={100}>
+							{form.images.filter((img) => img !== coverImage).map((item) => (
+								<ImageListItem key={item.id}>
+									<img
+										src={item.url || (item.file ? URL.createObjectURL(item.file) : "")}
+										alt="Property preview"
+										loading="lazy"
+										style={{ borderRadius: 8, height: "100%", objectFit: "cover" }}
+									/>
+								</ImageListItem>
+							))}
+						</ImageList>
+					</Paper>
+				</Grid>
+			</Grid>
+		</Box>
+	);
+};
+
+export default StepPreviewBox;

--- a/UI/src/features/owner/const/StepperMetaConst.ts
+++ b/UI/src/features/owner/const/StepperMetaConst.ts
@@ -3,6 +3,7 @@ import MeetingRoomOutlinedIcon from "@mui/icons-material/MeetingRoomOutlined";
 import KingBedOutlinedIcon from "@mui/icons-material/KingBedOutlined";
 import PhotoLibraryOutlinedIcon from "@mui/icons-material/PhotoLibraryOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
+import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import type { SvgIconComponent } from "@mui/icons-material";
 
 interface StepMeta {
@@ -17,4 +18,5 @@ export const STEP_META: StepMeta[] = [
 	{ label: "Facilities", subtitle: "What you offer", icon: MeetingRoomOutlinedIcon },
 	{ label: "Rooms", subtitle: "Rooms & beds", icon: KingBedOutlinedIcon },
 	{ label: "Photos", subtitle: "Images & cover", icon: PhotoLibraryOutlinedIcon },
+	{ label: "Preview", subtitle: "Review & publish", icon: VisibilityOutlinedIcon },
 ];

--- a/UI/src/features/owner/hooks/useDeleteImage.ts
+++ b/UI/src/features/owner/hooks/useDeleteImage.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteImageApi } from "../services/ownerApi";
+
+export const useDeleteImage = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (imageId: string) => deleteImageApi(imageId),
+		onSuccess: () => {
+			// You might want to invalidate queries that fetch images
+			queryClient.invalidateQueries({ queryKey: ["accommodationImages"] });
+			queryClient.invalidateQueries({ queryKey: ["roomImages"] });
+		},
+	});
+};

--- a/UI/src/features/owner/hooks/useDeleteRoom.ts
+++ b/UI/src/features/owner/hooks/useDeleteRoom.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteRoomApi } from "../services/ownerApi";
+import type { RoomForm } from "../types/owner.types";
+
+export const useDeleteRoom = (accommodationId: string) => {
+	const queryClient = useQueryClient();
+
+	return useMutation<void, Error, string>({
+		mutationFn: (roomId) => deleteRoomApi(roomId),
+
+		onSuccess: (_, roomId) => {
+			// Update the cached room list for this accommodation
+			queryClient.setQueryData(["accommodation", accommodationId, "rooms"], (old: RoomForm[] | undefined) => (old ?? []).filter((r) => r.id !== roomId));
+		},
+
+		onError: (err) => {
+			console.error("Delete room failed:", err.message);
+		},
+	});
+};

--- a/UI/src/features/owner/hooks/useGetImages.ts
+++ b/UI/src/features/owner/hooks/useGetImages.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import { getEntityImages } from "../services/ownerApi";
+import type { ImageItem } from "../types/owner.types";
+
+export const useGetImages = (accommodationId?: string, roomIds: string[] = []) => {
+	return useQuery<ImageItem[]>({
+		queryKey: ["accommodation", accommodationId, "all-images"],
+		queryFn: async () => {
+			if (!accommodationId) return [];
+
+			const results: ImageItem[] = [];
+
+			// 1. Fetch accommodation images
+			try {
+				const accomImages = await getEntityImages("accommodation", accommodationId);
+				accomImages?.forEach((img) => {
+					results.push({
+						id: img.id,
+						url: img.url,
+						target: "accommodation",
+					});
+				});
+			} catch (err) {
+				console.error("Failed to fetch accommodation images", err);
+			}
+
+			// 2. Fetch room images
+			await Promise.all(
+				roomIds.map(async (roomId) => {
+					try {
+						const roomImages = await getEntityImages("room", roomId);
+						roomImages?.forEach((img) => {
+							results.push({
+								id: img.id,
+								url: img.url,
+								target: "room",
+								roomId: roomId,
+							});
+						});
+					} catch (err) {
+						console.error(`Failed to fetch images for room ${roomId}`, err);
+					}
+				})
+			);
+
+			return results;
+		},
+		enabled: !!accommodationId,
+		staleTime: 5 * 60 * 1000,
+	});
+};

--- a/UI/src/features/owner/hooks/useUploadImages.ts
+++ b/UI/src/features/owner/hooks/useUploadImages.ts
@@ -1,0 +1,45 @@
+import { useMutation } from "@tanstack/react-query";
+import { uploadAccommodationImages, uploadRoomImages } from "../services/ownerApi";
+import type { ImageItem } from "../types/owner.types";
+
+interface UploadImagesPayload {
+	accommodationId: string;
+	images: ImageItem[];
+}
+
+export const useUploadImages = () => {
+	return useMutation<void, Error, UploadImagesPayload>({
+		mutationFn: async ({ accommodationId, images }) => {
+			const accommodationFiles = images
+				.filter((img) => img.target === "accommodation" && img.file)
+				.map((img) => img.file as File);
+
+			const roomImages = images.filter((img) => img.target === "room" && img.file && img.roomId);
+			const roomFilesMap = roomImages.reduce((acc, img) => {
+				const roomId = img.roomId!;
+				if (!acc[roomId]) {
+					acc[roomId] = [];
+				}
+				acc[roomId].push(img.file as File);
+				return acc;
+			}, {} as Record<string, File[]>);
+
+			const uploadPromises: Promise<void>[] = [];
+
+			if (accommodationFiles.length > 0) {
+				uploadPromises.push(uploadAccommodationImages(accommodationId, accommodationFiles));
+			}
+
+			for (const [roomId, files] of Object.entries(roomFilesMap)) {
+				if (files.length > 0) {
+					uploadPromises.push(uploadRoomImages(roomId, files));
+				}
+			}
+
+			await Promise.all(uploadPromises);
+		},
+		onError: (err) => {
+			console.error("Upload images failed:", err.message);
+		},
+	});
+};

--- a/UI/src/features/owner/pages/OwnerCreateAccomPage.tsx
+++ b/UI/src/features/owner/pages/OwnerCreateAccomPage.tsx
@@ -6,7 +6,8 @@ import StepBasicInfoBox from "../components/Wizard/Step2/StepBasicInfoBox";
 import StepAddressBox from "../components/Wizard/Step3/StepAddressBox";
 import StepFacilityBox from "../components/Wizard/Step4/StepFacilityBox";
 import StepRoomsBox from "../components/Wizard/Step5/StepRoomBox";
-// import StepImageBox from "../components/Wizard/Step6/StepImageBox";
+import StepImageBox from "../components/Wizard/Step6/StepImageBox";
+import StepPreviewBox from "../components/Wizard/Step7/StepPreviewBox";
 
 import { type WizardForm } from "../types/owner.types";
 import { ERentalType, EAccommodationType } from "../../accommodation/types/accommodation.types";
@@ -48,6 +49,13 @@ function validateStep(step: number, form: WizardForm): string | null {
 			}
 			return null;
 		}
+		case 4: {
+			if (form.images.length === 0) return "Please upload at least one image.";
+			return null;
+		}
+		case 5: {
+			return null;
+		}
 		default:
 			return null;
 	}
@@ -61,7 +69,7 @@ const OwnerCreateAccomPage = () => {
 	const [completed, setCompleted] = useState<Set<number>>(new Set());
 	const [validationError, setValidationError] = useState<string | null>(null);
 
-	// V2 triger for Step 0, 1, 2
+	// V2 triger for Step 0, 1, 2, 4
 	const [triggerSubmit, setTriggerSubmit] = useState(false);
 
 	// V1 trigger for Step 3 (Rooms)
@@ -135,9 +143,15 @@ const OwnerCreateAccomPage = () => {
 
 		setValidationError(null); // Xóa lỗi cũ trước khi tiến hành
 
-		// Các bước 0, 1, 2 dùng triggerSubmit chung
-		if (step === 0 || step === 1 || step === 2) {
+		// Các bước 0, 1, 2, 4 dùng triggerSubmit chung
+		if (step === 0 || step === 1 || step === 2 || step === 4) {
 			setTriggerSubmit(true);
+			return;
+		}
+
+		if (step === 5) {
+			// TODO: actually call API
+			alert("Accommodation published successfully!");
 			return;
 		}
 
@@ -225,8 +239,22 @@ const OwnerCreateAccomPage = () => {
 						onSaveFailed={() => setTriggerRoomSave(false)}
 					/>
 				);
-			// case 4:
-			// 	return <StepImageBox form={form} setForm={setForm} />;
+			case 4:
+				return (
+					<StepImageBox
+						form={form}
+						setForm={setForm}
+						onFieldChange={() => setValidationError(null)}
+						triggerSubmit={triggerSubmit}
+						resetTrigger={() => setTriggerSubmit(false)}
+						onSuccess={() => {
+							setCompleted((prev) => new Set(prev).add(4));
+							setStep(5);
+						}}
+					/>
+				);
+			case 5:
+				return <StepPreviewBox form={form} />;
 			default:
 				return null;
 		}
@@ -268,7 +296,7 @@ const OwnerCreateAccomPage = () => {
 							</Typography>
 
 							{isLastStep ? (
-								<Button variant="contained" color="success" sx={{ minWidth: 140, borderRadius: 2, fontWeight: 700 }} onClick={() => alert("Submit form!")}>
+								<Button variant="contained" color="success" sx={{ minWidth: 140, borderRadius: 2, fontWeight: 700 }} onClick={next}>
 									Publish Listing
 								</Button>
 							) : (

--- a/UI/src/features/owner/services/ownerApi.ts
+++ b/UI/src/features/owner/services/ownerApi.ts
@@ -125,6 +125,8 @@ export const uploadAccommodationImages = (accommodationId: string, files: File[]
 
 export const uploadRoomImages = (roomId: string, files: File[]): Promise<void> => uploadInChunks(`/images/room/${roomId}`, files);
 
+export const deleteImageApi = async (imageId: string): Promise<void> => apiClient.delete(`/images/${imageId}`).then(() => undefined);
+
 // export const getAmenities = async (): Promise<AmenityDto[]> => apiClient.get<ApiResponse<AmenityDto[]>>("/amenities").then((res) => res.data.data);
 
 // export const getFacilities = async (): Promise<FacilityDto[]> => apiClient.get<ApiResponse<FacilityDto[]>>("/facilities").then((res) => res.data.data);

--- a/UI/src/features/owner/services/ownerApi.ts
+++ b/UI/src/features/owner/services/ownerApi.ts
@@ -96,34 +96,34 @@ export const updateRoom = async (roomId: string, payload: UpdateRoomDTO): Promis
 		return data;
 	});
 
+export const deleteRoomApi = async (roomId: string): Promise<void> => apiClient.delete(`/owners/rooms/${roomId}`).then(() => undefined);
+
 // // ─── Step 6: Images ───────────────────────────────────────────────────────────
-// // Max 10 files per request. Use uploadAccommodationImages/uploadRoomImages
-// // which handle chunking automatically.
 
-// const CHUNK_SIZE = 10;
+export const getEntityImages = async (type: "accommodation" | "room", id: string) => apiClient.get<ApiResponse<{ id: string; url: string }[]>>(`/images/${type}/${id}`).then((res) => res.data.data);
 
-// const uploadChunk = (url: string, files: File[]): Promise<void> => {
-// 	const formData = new FormData();
-// 	files.forEach((file) => formData.append("files", file));
-// 	return apiClient
-// 		.post(url, formData, {
-// 			headers: { "Content-Type": "multipart/form-data" },
-// 		})
-// 		.then(() => undefined);
-// };
+// Splits files into chunks of 10 and fires sequential requests.
+const uploadInChunks = async (url: string, files: File[]): Promise<void> => {
+	// Max 10 files per request.
+	const CHUNK_SIZE = 10;
 
-// // Splits files into chunks of 10 and fires sequential requests.
-// const uploadInChunks = async (url: string, files: File[]): Promise<void> => {
-// 	for (let i = 0; i < files.length; i += CHUNK_SIZE) {
-// 		await uploadChunk(url, files.slice(i, i + CHUNK_SIZE));
-// 	}
-// };
+	const uploadChunk = async (url: string, files: File[]): Promise<void> => {
+		const formData = new FormData();
+		files.forEach((file) => formData.append("files", file));
+		return apiClient
+			.post(url, formData, {
+				headers: { "Content-Type": "multipart/form-data" },
+			})
+			.then(() => undefined);
+	};
+	for (let i = 0; i < files.length; i += CHUNK_SIZE) {
+		await uploadChunk(url, files.slice(i, i + CHUNK_SIZE));
+	}
+};
 
-// export const uploadAccommodationImages = (accommodationId: string, files: File[]): Promise<void> => uploadInChunks(`/images/accommodation/${accommodationId}`, files);
+export const uploadAccommodationImages = (accommodationId: string, files: File[]): Promise<void> => uploadInChunks(`/images/accommodation/${accommodationId}`, files);
 
-// export const uploadRoomImages = (roomId: string, files: File[]): Promise<void> => uploadInChunks(`/images/room/${roomId}`, files);
-
-// // ─── Lookups ──────────────────────────────────────────────────────────────────
+export const uploadRoomImages = (roomId: string, files: File[]): Promise<void> => uploadInChunks(`/images/room/${roomId}`, files);
 
 // export const getAmenities = async (): Promise<AmenityDto[]> => apiClient.get<ApiResponse<AmenityDto[]>>("/amenities").then((res) => res.data.data);
 


### PR DESCRIPTION
### Overview
This pull request implements the missing image deletion logic within the Owner Registration Wizard (Step 6). Previously, the system did not handle cases where a user uploaded images and then decided to remove or edit them. This update ensures that deleting an image from the UI correctly synchronizes with the backend by removing database records and purging the corresponding files from S3 storage.

### Key Changes

#### 1. Backend: Atomic Deletion Logic
- **Repository Layer**: Added `deleteImage` to `ImageRepository`. It uses a Prisma transaction to atomically delete the `Image` record along with its `ImageVariant` and `ImageReference` dependencies.
- **Service Layer**: Updated `ImageService` to orchestrate deletion between the database and S3 storage, ensuring no "orphaned" files remain in the cloud.
- **API Layer**: 
    - Defined a new `DeleteImageRequest` type for better type safety.
    - Implemented `ImageController.delete` method.
    - Registered the `DELETE /images/:id` route, protected by `authMiddleware`.

#### 2. Frontend: Seamless Wizard Integration
- **API Service**: Added `deleteImageApi` to the owner service layer.
- **Hooks**: Created a specialized `useDeleteImage` mutation hook using React Query to handle server-side deletion and cache invalidation.
- **UI (StepImageBox)**: 
    - Updated the `handleRemoveImage` logic in the wizard's photo step.
    - Added a smart check: if an image is only in the local state (newly picked), it is removed instantly. If it exists on the server (already uploaded), the system calls the deletion API before updating the local UI state.

### Impact
- **Storage Efficiency**: Prevents S3 bucket bloat by deleting unused files immediately.
- **Data Integrity**: Ensures the database only reflects images currently visible to the owner.
- **User Experience**: Provides a fluid, bug-free "Edit" experience during the property and room registration process.

### Testing Status
- [x] Verified single image deletion for Accommodations.
- [x] Verified single image deletion for specific Rooms.
- [x] Confirmed S3 files are removed upon DB record deletion.
- [ ] Confirmed local-only images (pre-upload) are removed without API calls.

### TODO / Next Steps
- Implement automatic cleanup for old User Avatars when a new profile picture is uploaded.
