### PR TITLE
feat/money-converter-utils

### DIFF
--- a/API/monolith-service/.env.example
+++ b/API/monolith-service/.env.example
@@ -35,3 +35,7 @@ PINECONE_API_KEY=your-pinecone-api-key
 PINECONE_INDEX_NAME=your-index-name (e.g. index-review)
 
 GEMINI_API_KEY=your-gemini-api-key
+
+PAYOS_CLIENT_ID = your-payos-client-id
+PAYOS_API_KEY =  your-payos-api-key
+PAYOS_CHECKSUM_KEY = your-payos-checksum-key

--- a/UI/src/features/accommodation/components/detail/BookingCard.tsx
+++ b/UI/src/features/accommodation/components/detail/BookingCard.tsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useSearchParams } from "react-router-dom";
 import type { RootState } from "../../../../app/store";
 import { setBookingField } from "../../../booking/bookingSlice";
+import { useCurrency } from "../../../../hooks/useCurrency";
 
 interface Props {
 	rooms: ItemInfo[];
@@ -21,6 +22,7 @@ export const BookingCard = ({ rooms, nights, totalPrice }: Props) => {
 	const dispatch = useDispatch();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const bookingInfo = useSelector((state: RootState) => state.booking);
+	const { format } = useCurrency();
 
 	const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 	const [dates, setDates] = useState<Dates>({
@@ -53,7 +55,7 @@ export const BookingCard = ({ rooms, nights, totalPrice }: Props) => {
 					Total for {nights} {nights === 1 ? "night" : "nights"}
 				</Typography>
 				<Typography variant="h4" fontWeight="bold" color="primary">
-					${totalPrice.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+					{format(totalPrice)}
 				</Typography>
 			</Box>
 			<Divider sx={{ my: 2 }} />

--- a/UI/src/features/accommodation/components/detail/tabs/Overview/components/FacilitiesSection.tsx
+++ b/UI/src/features/accommodation/components/detail/tabs/Overview/components/FacilitiesSection.tsx
@@ -1,12 +1,15 @@
 import { Paper, Typography, Grid, Box } from "@mui/material";
 import { facilityIcons } from "../../../../../constants/facilityIcons";
 import type { AccommodationDetail } from "../../../../../types/accommodation.types";
+import { useCurrency } from "../../../../../../../hooks/useCurrency";
 
 interface Props {
 	accommodation: AccommodationDetail;
 }
 
 export const FacilitiesSection = ({ accommodation }: Props) => {
+	const { format } = useCurrency();
+
 	return (
 		<Paper sx={{ p: 4, mb: 3, borderRadius: 2, border: "1px solid", borderColor: "divider", boxShadow: "none" }}>
 			<Typography variant="h6" fontWeight="600" sx={{ mb: 3 }}>
@@ -35,7 +38,7 @@ export const FacilitiesSection = ({ accommodation }: Props) => {
 									</Typography>
 									{parseFloat(f.fee) > 0 && (
 										<Typography variant="caption" fontWeight="700" color="primary.main">
-											${f.fee}
+											{format(parseFloat(f.fee))}
 										</Typography>
 									)}
 								</Box>

--- a/UI/src/features/accommodation/components/detail/tabs/Rooms/components/RoomCard.tsx
+++ b/UI/src/features/accommodation/components/detail/tabs/Rooms/components/RoomCard.tsx
@@ -7,6 +7,7 @@ import { getViewTypeLabel } from "../../../../../constants/viewTypes";
 import useModalContext from "../../../../../../../context/ModalContext/hook";
 import RoomDetailModal from "./RoomDetailModal";
 import type { Room } from "../../../../../types/room.types";
+import { useCurrency } from "../../../../../../../hooks/useCurrency";
 
 interface RoomCardProps {
 	room: Room;
@@ -17,6 +18,7 @@ interface RoomCardProps {
 }
 
 export const RoomCard = ({ room, quantity, availableRooms, onIncrease, onDecrease }: RoomCardProps) => {
+	const { format } = useCurrency();
 	const isLowStock = availableRooms <= 3;
 	const price = parseFloat(room.price);
 
@@ -246,7 +248,7 @@ export const RoomCard = ({ room, quantity, availableRooms, onIncrease, onDecreas
 									fontSize: { xs: "1.75rem", sm: "2rem" },
 								}}
 							>
-								${price}
+								{format(price)}
 							</Typography>
 							<Typography
 								variant="caption"

--- a/UI/src/features/accommodation/components/detail/tabs/Rooms/components/RoomDetailModal.tsx
+++ b/UI/src/features/accommodation/components/detail/tabs/Rooms/components/RoomDetailModal.tsx
@@ -5,6 +5,7 @@ import { Close, Person, Hotel, SquareFoot, Bathtub, Visibility, ChevronLeft, Che
 import { getViewTypeLabel } from "../../../../../constants/viewTypes";
 import useModalContext from "../../../../../../../context/ModalContext/hook";
 import type { Room } from "../../../../../types/room.types";
+import { useCurrency } from "../../../../../../../hooks/useCurrency";
 
 interface RoomDetailModalProps {
 	room: Room;
@@ -12,9 +13,10 @@ interface RoomDetailModalProps {
 
 const RoomDetailModal = ({ room }: RoomDetailModalProps) => {
 	const { closeModal } = useModalContext();
+	const { format } = useCurrency();
 
 	const primaryImages = room.images.filter((img) => img.variants.some((v) => v.variant === "ORIGINAL"));
-	const price = Math.floor(parseFloat(room.price));
+	const price = parseFloat(room.price);
 
 	const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
@@ -182,7 +184,7 @@ const RoomDetailModal = ({ room }: RoomDetailModalProps) => {
 				>
 					<Box>
 						<Typography variant="h5" fontWeight={700} color="primary.main">
-							${price}
+							{format(price)}
 						</Typography>
 						<Typography variant="caption" color="text.secondary">
 							per night

--- a/UI/src/features/accommodation/components/search/AccommodationCard.tsx
+++ b/UI/src/features/accommodation/components/search/AccommodationCard.tsx
@@ -4,7 +4,7 @@ import { LocationOn, AutoAwesome } from "@mui/icons-material";
 import type { AccommodationDetail } from "../../types/accommodation.types";
 import { ACCOMMODATION_TYPE_OPTIONS } from "../../constants/searchFilters";
 import FavouriteButton from "../../../../components/shared/FavouriteButton";
-import { standardize } from "../../../../utils/moneyConverter";
+import { useCurrency } from "../../../../hooks/useCurrency";
 import { ACCOMMODATION_DEFAULT_IMAGES } from "../../types/const";
 
 interface Props {
@@ -21,6 +21,7 @@ const getTypeLabel = (type: string): string => {
 };
 
 export const AccommodationCard: React.FC<Props> = ({ accommodation, variant, onClick, score, matchReason }) => {
+	const { format } = useCurrency();
 	const minPrice = accommodation.minPrice;
 
 	const avgStar = accommodation.avgStar;
@@ -102,7 +103,7 @@ export const AccommodationCard: React.FC<Props> = ({ accommodation, variant, onC
 										Starting from
 									</Typography>
 									<Typography variant="h5" color="primary" fontWeight="bold">
-										${standardize(minPrice || 100)}
+										{format(minPrice || 100)}
 									</Typography>
 									<Typography variant="caption" color="text.secondary">
 										per night
@@ -259,7 +260,7 @@ export const AccommodationCard: React.FC<Props> = ({ accommodation, variant, onC
 								From
 							</Typography>{" "}
 							<Typography variant="h6" color="primary" fontWeight="bold">
-								${standardize(minPrice || 100)}
+								{format(minPrice || 100)}
 							</Typography>
 							<Typography variant="body2" color="text.secondary" sx={{ ml: 0.5 }}>
 								/ night

--- a/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
+++ b/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
@@ -20,11 +20,10 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 	// Get data from Redux (url synced by parent)
 	const criteria = useSelector((state: RootState) => state.search);
 
-	// Local state only used for smooth UI slibar
-	const [localPrice, setLocalPrice] = useState<number[]>([criteria.price.min, criteria.price.max]);
+	// Local state for smooth UI slider, always in current currency
+	const [localPrice, setLocalPrice] = useState<number[]>([]);
 
 	// Sync: when Redux changes due to URL change, update local state
-	// to make sure back/forward works
 	useEffect(() => {
 		setLocalPrice([criteria.price.min, criteria.price.max]);
 	}, [criteria.price.min, criteria.price.max]);
@@ -57,8 +56,6 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 	};
 
 	// Slider logic:
-	// - onChange: only update UI local
-	// - onChangeCommitted: Update URL (to fetch data)
 	const handleSliderChange = (_: Event, newValue: number | number[]) => {
 		if (Array.isArray(newValue)) {
 			setLocalPrice(newValue);
@@ -68,8 +65,8 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 	const handleSliderCommit = (_: Event | React.SyntheticEvent | null, newValue: number | number[]) => {
 		if (Array.isArray(newValue)) {
 			updateFilter({
-				minPrice: newValue[0].toString(),
-				maxPrice: newValue[1].toString(),
+				minPrice: Math.round(newValue[0]).toString(),
+				maxPrice: Math.round(newValue[1]).toString(),
 			});
 		}
 	};
@@ -78,14 +75,13 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 	const handleInputChange = (type: "min" | "max", value: string) => {
 		const numVal = Number(value);
 		const newRange = type === "min" ? [numVal, localPrice[1]] : [localPrice[0], numVal];
-
 		setLocalPrice(newRange);
 	};
 
 	const handleInputCommit = () => {
 		updateFilter({
-			minPrice: localPrice[0].toString(),
-			maxPrice: localPrice[1].toString(),
+			minPrice: Math.round(localPrice[0]).toString(),
+			maxPrice: Math.round(localPrice[1]).toString(),
 		});
 	};
 
@@ -175,19 +171,27 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 							label="Min"
 							size="small"
 							type="number"
-							value={localPrice[0]}
+							value={localPrice[0] || 0}
 							onChange={(e) => handleInputChange("min", e.target.value)}
 							onBlur={handleInputCommit}
-							slotProps={{ input: { startAdornment: <InputAdornment position="start">$</InputAdornment> } }}
+							slotProps={{
+								input: {
+									startAdornment: <InputAdornment position="start">VND</InputAdornment>,
+								},
+							}}
 						/>
 						<TextField
 							label="Max"
 							size="small"
 							type="number"
-							value={localPrice[1]}
+							value={localPrice[1] || 0}
 							onChange={(e) => handleInputChange("max", e.target.value)}
 							onBlur={handleInputCommit}
-							slotProps={{ input: { startAdornment: <InputAdornment position="start">$</InputAdornment> } }}
+							slotProps={{
+								input: {
+									startAdornment: <InputAdornment position="start">VND</InputAdornment>,
+								},
+							}}
 						/>
 					</Box>
 				</Box>

--- a/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
+++ b/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
@@ -173,6 +173,7 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 							value={localPrice[0] || 0}
 							onChange={(e) => handleInputChange("min", e.target.value)}
 							onBlur={handleInputCommit}
+							inputProps={{ step: 1000 }}
 							slotProps={{
 								input: {
 									endAdornment: <InputAdornment position="end">VND</InputAdornment>,
@@ -186,9 +187,10 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 							value={localPrice[1] || 0}
 							onChange={(e) => handleInputChange("max", e.target.value)}
 							onBlur={handleInputCommit}
+							inputProps={{ step: 1000 }}
 							slotProps={{
 								input: {
-									startAdornment: <InputAdornment position="start">VND</InputAdornment>,
+									endAdornment: <InputAdornment position="end">VND</InputAdornment>,
 								},
 							}}
 						/>

--- a/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
+++ b/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
@@ -21,8 +21,7 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 	const criteria = useSelector((state: RootState) => state.search);
 
 	// Local state for smooth UI slider, always in current currency
-	const [localPrice, setLocalPrice] = useState<number[]>([]);
-
+	const [localPrice, setLocalPrice] = useState<number[]>([criteria.price.min, criteria.price.max]);
 	// Sync: when Redux changes due to URL change, update local state
 	useEffect(() => {
 		setLocalPrice([criteria.price.min, criteria.price.max]);

--- a/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
+++ b/UI/src/features/accommodation/components/search/SearchFiltersSidebar.tsx
@@ -176,7 +176,7 @@ export const SearchFiltersSidebar: React.FC<SearchFiltersSidebarProps> = ({ faci
 							onBlur={handleInputCommit}
 							slotProps={{
 								input: {
-									startAdornment: <InputAdornment position="start">VND</InputAdornment>,
+									endAdornment: <InputAdornment position="end">VND</InputAdornment>,
 								},
 							}}
 						/>

--- a/UI/src/features/accommodation/constants/searchFilters.tsx
+++ b/UI/src/features/accommodation/constants/searchFilters.tsx
@@ -116,8 +116,8 @@ export const FACILITY_FILTER_OPTIONS: FacilityFilterOption[] = [
 
 export const PRICE_FILTER_CONFIG = {
 	MIN: 0,
-	MAX: 2000,
-	STEP: 10,
+	MAX: 5000000,
+	STEP: 100000,
 };
 
 export const SORT_OPTIONS: SortOptionItem[] = [

--- a/UI/src/features/accommodation/pages/SearchResultPage.tsx
+++ b/UI/src/features/accommodation/pages/SearchResultPage.tsx
@@ -6,7 +6,6 @@ import { SearchFiltersSidebar, ActiveFiltersBar, ResultsHeader, AccommodationCar
 
 import { useScrollToTopOnMount } from "../../../hooks/useScrollToTopMount";
 import { PRICE_FILTER_CONFIG } from "../constants/searchFilters";
-import { standardize } from "../../../utils/moneyConverter";
 import { usePushNotificationContext } from "../../../context/PushNotification/hook";
 import SearchBar from "../components/search/SearchBar/SearchBar";
 import { useDispatch, useSelector } from "react-redux";
@@ -17,12 +16,14 @@ import { parseSearchParamsToQuery } from "../../../utils/search";
 import useFacilityList from "../hooks/useFacilityList";
 import { EAccommodationType } from "../types/accommodation.types";
 import { AdvancedSearchButton } from "../../search/semantic-search/AdvancedSearchButton";
+import { useCurrency } from "../../../hooks/useCurrency";
 
 export default function SearchResultPage() {
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
 	const dispatch = useDispatch();
 	const { pushNotification } = usePushNotificationContext();
+	const { format } = useCurrency();
 
 	const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
 
@@ -117,7 +118,7 @@ export default function SearchResultPage() {
 			filters.push({
 				key: "price",
 				label: "Khoảng giá",
-				value: `${standardize(min)} - ${standardize(max)}`,
+				value: `${format(min)} - ${format(max)}`,
 			});
 		}
 
@@ -130,7 +131,7 @@ export default function SearchResultPage() {
 		}
 
 		return filters;
-	}, [criteria, facilities]);
+	}, [criteria, facilities, format]);
 
 	useScrollToTopOnMount();
 

--- a/UI/src/features/booking/components/PreviewBooking/AccommodationInfoBox.tsx
+++ b/UI/src/features/booking/components/PreviewBooking/AccommodationInfoBox.tsx
@@ -7,6 +7,7 @@ import type { RoomFullDetail } from "../../../accommodation/types/room.types";
 import useAccommodation from "../../../accommodation/hooks/useAccommodation";
 import type { RootState } from "../../../../app/store";
 import { useSelector } from "react-redux";
+import { useCurrency } from "../../../../hooks/useCurrency";
 
 type BookingRoom = RoomFullDetail & {
 	count: number;
@@ -26,6 +27,7 @@ interface Props {
 const AccommodationInfoBox: React.FC<Props> = ({ accommInfo, rooms, agreed, setAgreed, setGalleryImages, openImageGallery, handleProceed }) => {
 	const bookingContext = useSelector((state: RootState) => state.booking);
 	const { data: accomImages, isLoading: accomImagesLoading } = useAccommodation(accommInfo?.id ?? "");
+	const { format } = useCurrency();
 
 	if (!accommInfo) {
 		return <Typography>Accommodation not found</Typography>;
@@ -174,7 +176,7 @@ const AccommodationInfoBox: React.FC<Props> = ({ accommInfo, rooms, agreed, setA
 						Total Price
 					</Typography>
 					<Typography variant="h4" fontWeight="bold" color="primary">
-						${totalPrice.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+						{format(totalPrice)}
 					</Typography>
 				</Box>
 

--- a/UI/src/features/booking/components/PreviewBooking/RoomReviewCard.tsx
+++ b/UI/src/features/booking/components/PreviewBooking/RoomReviewCard.tsx
@@ -2,6 +2,7 @@ import { Box, Typography, Modal, Chip } from "@mui/material";
 import React, { useState, type Dispatch, type SetStateAction } from "react";
 import type { Image } from "../../../../types/Image";
 import type { RoomFullDetail } from "../../../accommodation/types/room.types";
+import { useCurrency } from "../../../../hooks/useCurrency";
 
 type RoomReviewCardProps = {
 	room: RoomFullDetail & { count: number };
@@ -15,6 +16,7 @@ type RoomReviewCardProps = {
 
 const RoomReviewCard: React.FC<RoomReviewCardProps> = ({ room, thumbnail, images, loading, setGalleryImages, openImageGallery, amenities }) => {
 	const [open, setOpen] = useState(false);
+	const { format } = useCurrency();
 
 	// Flat mapping logic remains consistent with the new Amenity interface
 	const flatAmenities = (amenities || [])
@@ -105,11 +107,7 @@ const RoomReviewCard: React.FC<RoomReviewCardProps> = ({ room, thumbnail, images
 					</Box>
 
 					<Typography variant="h6" fontWeight="bold" color="primary.main" textAlign="right">
-						$
-						{Number.parseFloat(room.price).toLocaleString("en-US", {
-							minimumFractionDigits: 2,
-							maximumFractionDigits: 2,
-						})}
+						{format(Number.parseFloat(room.price))}
 					</Typography>
 				</Box>
 			</Box>

--- a/UI/src/features/home/components/owner/sections/HeroSection.tsx
+++ b/UI/src/features/home/components/owner/sections/HeroSection.tsx
@@ -5,6 +5,7 @@ import FiberManualRecordIcon from "@mui/icons-material/FiberManualRecord";
 import StarRoundedIcon from "@mui/icons-material/StarRounded";
 import AddHomeWorkRoundedIcon from "@mui/icons-material/AddHomeWorkRounded";
 import AmbientBlobs from "../AmbientBlobs";
+import { useCurrency } from "../../../../../hooks/useCurrency";
 
 interface HeroSectionProps {
 	scrollY: number;
@@ -13,6 +14,8 @@ interface HeroSectionProps {
 }
 
 const HeroSection: React.FC<HeroSectionProps> = ({ scrollY, onGetStarted, exampleImage }) => {
+	const { format } = useCurrency();
+
 	return (
 		<Box
 			sx={{
@@ -176,7 +179,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ scrollY, onGetStarted, exampl
 							}}
 						>
 							<Typography sx={{ color: "#080d1a", fontSize: "0.65rem", fontWeight: 700, letterSpacing: "0.08em" }}>THIS MONTH</Typography>
-							<Typography sx={{ color: "#080d1a", fontSize: "1.5rem", fontWeight: 800 }}>$2,840</Typography>
+							<Typography sx={{ color: "#080d1a", fontSize: "1.5rem", fontWeight: 800 }}>{format(28400000)}</Typography>
 						</Box>
 
 						<Box

--- a/UI/src/features/owner/components/Wizard/Step4/FacilityCard.tsx
+++ b/UI/src/features/owner/components/Wizard/Step4/FacilityCard.tsx
@@ -5,6 +5,7 @@ import type { FacilityDto } from "../../../types/owner.types";
 import type { FacilityConfig } from "../../../../accommodation/types/accommodation.types";
 import type React from "react";
 import { EDIT_BG, EDIT_BORDER, getFacilityIcon } from "../../../const/FacilityConst";
+import { formatVND } from "../../../../../utils/moneyConverter";
 
 interface FacilityCardProps {
 	facility: FacilityDto;
@@ -92,7 +93,7 @@ const FacilityCard: React.FC<FacilityCardProps> = ({ facility, entry, isSelected
 				</Typography>
 				{entry && (entry.fee ?? 0) > 0 && !isEditing && (
 					<Typography variant="caption" sx={{ mt: 0.5, color: "warning.main", fontSize: "0.68rem", fontWeight: 700 }}>
-						{entry.fee!.toLocaleString()}₫
+						{formatVND(entry.fee!)}
 					</Typography>
 				)}
 			</Box>

--- a/UI/src/features/owner/components/Wizard/Step5/RoomCard.tsx
+++ b/UI/src/features/owner/components/Wizard/Step5/RoomCard.tsx
@@ -10,6 +10,7 @@ import AspectRatioOutlinedIcon from "@mui/icons-material/AspectRatioOutlined";
 import LandscapeOutlinedIcon from "@mui/icons-material/LandscapeOutlined";
 import SellOutlinedIcon from "@mui/icons-material/SellOutlined";
 import type { RoomForm } from "../../../types/owner.types";
+import { formatVND } from "../../../../../utils/moneyConverter";
 
 interface Props {
 	room: RoomForm;
@@ -77,7 +78,7 @@ export default function RoomCard({ room, onEdit, onDelete }: Props) {
 					<SummaryItem icon={<BathtubOutlinedIcon />} label={`${room.bathroomCount} bath${room.bathroomCount !== 1 ? "s" : ""}`} />
 					{room.size ? <SummaryItem icon={<AspectRatioOutlinedIcon />} label={`${room.size} m²`} /> : null}
 					{room.viewType !== "NONE" ? <SummaryItem icon={<LandscapeOutlinedIcon />} label={`${room.viewType.replace(/_/g, " ")} view`} /> : null}
-					{room.price ? <SummaryItem icon={<SellOutlinedIcon />} label={`${room.price.toLocaleString("vi-VN")} VND / ${room.pricingType.replace(/_/g, " ").toLowerCase()}`} /> : null}
+					{room.price ? <SummaryItem icon={<SellOutlinedIcon />} label={`${formatVND(room.price)} / ${room.pricingType.replace(/_/g, " ").toLowerCase()}`} /> : null}
 				</Box>
 			</Box>
 

--- a/UI/src/features/owner/components/Wizard/Step7/StepPreviewBox.tsx
+++ b/UI/src/features/owner/components/Wizard/Step7/StepPreviewBox.tsx
@@ -4,6 +4,7 @@ import type { WizardForm, ImageItem, RoomForm } from "../../../types/owner.types
 import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
 import MeetingRoomOutlinedIcon from "@mui/icons-material/MeetingRoomOutlined";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import { formatVND } from "../../../../../utils/moneyConverter";
 
 const ImageGallery = lazy(() => import("../../../../../components/shared/ImageGallery"));
 
@@ -174,7 +175,7 @@ const StepPreviewBox = ({ form }: { form: WizardForm }) => {
 										{room.name}
 									</Typography>
 									<Typography variant="caption" fontWeight={700} color="primary">
-										{room.price ? `${Number(room.price).toLocaleString()} / ${room.pricingType.toLowerCase().replace(/_/g, " ")}` : "Price not set"}
+										{room.price ? `${formatVND(room.price)} / ${room.pricingType.toLowerCase().replace(/_/g, " ")}` : "Price not set"}
 									</Typography>
 								</Box>
 								<Typography variant="caption" color="text.secondary" display="block" mb={1}>

--- a/UI/src/features/owner/components/dashboard/DashboardStatsRow.tsx
+++ b/UI/src/features/owner/components/dashboard/DashboardStatsRow.tsx
@@ -3,7 +3,7 @@ import { alpha } from "@mui/material/styles";
 import { AccountBalanceWalletRounded, BedRounded, EventNoteRounded, ArrowForwardIosRounded } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
 import { useDashboardStats } from "../../hooks/useDashboardStats";
-import { standardize } from "../../../../utils/moneyConverter";
+import { formatVND } from "../../../../utils/moneyConverter";
 
 export const DashboardStatsRow = () => {
 	const { data: stats, isLoading, isError } = useDashboardStats();
@@ -69,10 +69,7 @@ export const DashboardStatsRow = () => {
 						</Box>
 
 						<Typography variant="h3" color="text.primary" sx={{ fontWeight: 700, fontSize: "2rem", mb: 0.5, display: "flex", alignItems: "baseline" }}>
-							{standardize(stats?.revenue || 0)}
-							<Typography component="span" variant="h5" sx={{ ml: 0.5, fontWeight: 600, color: "text.secondary" }}>
-								đ
-							</Typography>
+							{formatVND(stats?.revenue || 0)}
 						</Typography>
 
 						<Typography variant="caption" color="text.secondary" sx={{ opacity: 0.7, mt: "auto" }}>

--- a/UI/src/features/search/searchSlice.ts
+++ b/UI/src/features/search/searchSlice.ts
@@ -12,7 +12,7 @@ const initialState: Query = {
 	keyword: "",
 	dates: { checkIn: tomorrow, checkOut: dayAfter },
 	guests: { adults: 2, children: 0, rooms: 1 },
-	price: { min: 0, max: 500 },
+	price: { min: 0, max: 100000 },
 	type: EAccommodationType.HOTEL,
 	sortBy: "price_asc",
 	facilities: [],

--- a/UI/src/features/search/searchSlice.ts
+++ b/UI/src/features/search/searchSlice.ts
@@ -12,7 +12,7 @@ const initialState: Query = {
 	keyword: "",
 	dates: { checkIn: tomorrow, checkOut: dayAfter },
 	guests: { adults: 2, children: 0, rooms: 1 },
-	price: { min: 0, max: 100000 },
+	price: { min: 0, max: 1000000 },
 	type: EAccommodationType.HOTEL,
 	sortBy: "price_asc",
 	facilities: [],

--- a/UI/src/features/user/components/tabs/BookingsTab/BookingStatsOverview.tsx
+++ b/UI/src/features/user/components/tabs/BookingsTab/BookingStatsOverview.tsx
@@ -1,13 +1,14 @@
 import { Paper, Stack, Typography, Box } from "@mui/material";
 import type { Booking } from "../../../../booking/types/Booking";
 import { WalletOutlined, LuggageOutlined, NightsStayOutlined, StarRateRounded } from "@mui/icons-material";
-import { standardize } from "../../../../../utils/moneyConverter";
+import { useCurrency } from "../../../../../hooks/useCurrency";
 
 type BookingStatsOverviewProps = {
 	bookings: Booking[];
 };
 
 const BookingStatsOverview: React.FC<BookingStatsOverviewProps> = ({ bookings }) => {
+	const { format } = useCurrency();
 	const totalSpent = bookings.reduce((sum, b) => sum + Number(b.totalPrice), 0);
 	const upcomingBookings = bookings.filter((b) => b.status === "BOOKED" && new Date(b.startDate) > new Date());
 
@@ -26,7 +27,7 @@ const BookingStatsOverview: React.FC<BookingStatsOverviewProps> = ({ bookings })
 		{
 			label: "Total Spent",
 			icon: <WalletOutlined fontSize="large" />,
-			value: `$${standardize(totalSpent)}`,
+			value: format(totalSpent),
 			bgColor: "#d1f3d1", // xanh USD
 		},
 		{

--- a/UI/src/features/user/components/tabs/FavouritesTab/AccommodationCard.tsx
+++ b/UI/src/features/user/components/tabs/FavouritesTab/AccommodationCard.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { Place, StarRounded } from "@mui/icons-material";
 import { Box, Card, CardContent, CardMedia, IconButton, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button, Stack } from "@mui/material";
 import type { AccommodationDetail } from "../../../../accommodation/types/accommodation.types";
-import { standardize } from "../../../../../utils/moneyConverter";
 import { useNavigate } from "react-router-dom";
 import { getThumbnailUrl } from "../../../../../utils/image";
+import { useCurrency } from "../../../../../hooks/useCurrency";
 
 type AccommodationCardProps = {
 	accommodation: AccommodationDetail;
@@ -13,6 +13,7 @@ type AccommodationCardProps = {
 
 const AccommodationCard: React.FC<AccommodationCardProps> = ({ accommodation, onRemove }) => {
 	const navigate = useNavigate();
+	const { format } = useCurrency();
 	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	const images = accommodation?.images || [];
@@ -87,7 +88,7 @@ const AccommodationCard: React.FC<AccommodationCardProps> = ({ accommodation, on
 
 						<Stack direction="row" sx={{ textAlign: "right" }} alignItems={"end"} spacing={0.5}>
 							<Typography color="primary" fontWeight={700}>
-								{minPrice > 0 ? `$${standardize(minPrice)}` : "N/A"}
+								{minPrice > 0 ? format(minPrice) : "N/A"}
 							</Typography>
 							{minPrice > 0 && (
 								<Typography variant="caption" color="text.secondary">

--- a/UI/src/features/user/pages/ManageBookingDetailPage.tsx
+++ b/UI/src/features/user/pages/ManageBookingDetailPage.tsx
@@ -10,6 +10,7 @@ import { bookingApi } from "../../booking/services/bookingApi";
 import { usePayOS } from "@payos/payos-checkout";
 import { usePushNotificationContext } from "../../../context/PushNotification/hook";
 import type { Booking, PaymentTransfer } from "../../booking/types/Booking";
+import { formatVND } from "../../../utils/moneyConverter";
 
 const ManageBookingDetailPage = () => {
 	const { bookingId } = useParams<{ bookingId: string }>();
@@ -93,8 +94,6 @@ const ManageBookingDetailPage = () => {
 			minute: "2-digit",
 		});
 	};
-
-	const formatAmount = (amount: string, currency: string) => `${Number(amount).toLocaleString("vi-VN")} ${currency}`;
 
 	const getStatusConfig = (status: string) => {
 		switch (status) {
@@ -235,7 +234,7 @@ const ManageBookingDetailPage = () => {
 														Amount Paid
 													</Typography>
 													<Typography variant="body2" fontWeight={700} color="success.main">
-														{formatAmount(completedPayment.amount, completedPayment.currency)}
+														{formatVND(completedPayment.amount)}
 													</Typography>
 												</Stack>
 												<Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ px: 2, py: 1.5 }}>

--- a/UI/src/hooks/useCurrency.ts
+++ b/UI/src/hooks/useCurrency.ts
@@ -1,0 +1,7 @@
+import { formatVND } from "../utils/moneyConverter";
+
+export const useCurrency = () => {
+	return {
+		format: formatVND,
+	};
+};

--- a/UI/src/utils/moneyConverter.ts
+++ b/UI/src/utils/moneyConverter.ts
@@ -1,3 +1,25 @@
+/**
+ * Format a number to Vietnamese Dong (VND)
+ * Example: 123000.00 -> 123.000 VND
+ */
+export const formatVND = (amount: number | string): string => {
+	const num = typeof amount === "string" ? parseFloat(amount) : amount;
+	if (isNaN(num)) return "0 VND";
+
+	// Use dot as thousand separator and no decimals
+	const formatted = Math.round(num)
+		.toString()
+		.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+	return `${formatted} VND`;
+};
+
+/**
+ * Standardize remains for general numeric string formatting if needed, 
+ * but formatVND is preferred for prices.
+ */
 export const standardize = (amount: string | number) => {
-	return amount.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	const num = typeof amount === "string" ? parseFloat(amount) : amount;
+	if (isNaN(num)) return "0";
+	return Math.round(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 };

--- a/UI/src/utils/search.ts
+++ b/UI/src/utils/search.ts
@@ -3,7 +3,7 @@ import type { Query, SortOption } from "../features/search/types/Query";
 import { parseInputDate, toInputDate } from "./dateFormatter";
 
 const DEFAULT_GUESTS = { adults: 2, children: 0, rooms: 1 };
-const DEFAULT_PRICE = { min: 0, max: 100 };
+const DEFAULT_PRICE = { min: 0, max: 1000000 };
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 18;
 

--- a/UI/src/utils/search.ts
+++ b/UI/src/utils/search.ts
@@ -3,7 +3,7 @@ import type { Query, SortOption } from "../features/search/types/Query";
 import { parseInputDate, toInputDate } from "./dateFormatter";
 
 const DEFAULT_GUESTS = { adults: 2, children: 0, rooms: 1 };
-const DEFAULT_PRICE = { min: 0, max: 500 };
+const DEFAULT_PRICE = { min: 0, max: 100 };
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 18;
 


### PR DESCRIPTION
Feat: add utils to convert and format the US currentcy number to VND, as structured below:
- USD: Seperated by commas, count .00 after decimal number, e.g: 210,000.00 $
- VND: Seperated by dot notation, count up to .000 behind decimal number, e.g: 100.000 VND
